### PR TITLE
wip: tell jellyfin that playback uses live streams (improve latency)

### DIFF
--- a/mopidy_jellyfin/playback.py
+++ b/mopidy_jellyfin/playback.py
@@ -24,3 +24,8 @@ class JellyfinPlaybackProvider(backend.PlaybackProvider):
 
         else:
             return None
+
+    def is_live(self, uri):
+        # jellyfin streams are best handled as live
+        logger.debug('Jellyfin enabled live_stream for uri {}'.format(uri))
+        return True


### PR DESCRIPTION
improve latency of playback (the buffering that takes place when a track is selected) by using the Mopidy playback provider option `is_live`.

see: https://github.com/mopidy/mopidy/pull/1845