### PR TITLE
Switch away from legacy playback endpoint

### DIFF
--- a/mopidy_jellyfin/playback.py
+++ b/mopidy_jellyfin/playback.py
@@ -1,8 +1,11 @@
 from __future__ import unicode_literals
 
 import logging
+import random
+import string
 
 from mopidy import backend
+import mopidy_jellyfin
 
 
 logger = logging.getLogger(__name__)
@@ -10,14 +13,31 @@ logger = logging.getLogger(__name__)
 
 class JellyfinPlaybackProvider(backend.PlaybackProvider):
 
+    def __init__(self, audio, backend):
+        super(JellyfinPlaybackProvider, self).__init__(audio, backend)
+
     def translate_uri(self, uri):
         if uri.startswith('jellyfin:track:') and len(uri.split(':')) == 3:
-            id = uri.split(':')[-1]
+            item_id = uri.split(':')[-1]
+            # Build unique session ID
+            letters = string.ascii_letters
+            session_id = ''.join(random.choice(letters) for i in range(20))
+            # List of supported containers
+            container = 'opus,mp3,aac,m4a,flac,webma,webm,wav,ogg,mpa,wma'
 
-            url_params = { 'static': 'true' }
+            url_params = {
+                'MaxStreamingBitrate': '140000000',
+                'api_key': self.backend.remote.token,
+                'UserId': self.backend.remote.user_id,
+                'DeviceId': mopidy_jellyfin.Extension.device_id,
+                'PlaySessionId': session_id,
+                'TranscodingProtocol': 'hls',
+                'Container': container,
+                'AudioCodec': 'aac'
+            }
+
             track_url = self.backend.remote.api_url(
-                '/Audio/{}/stream'.format(id), url_params
-            )
+                f'/Audio/{item_id}/universal', url_params)
 
             logger.debug('Jellyfin track streaming url: {}'.format(track_url))
 

--- a/mopidy_jellyfin/playback.py
+++ b/mopidy_jellyfin/playback.py
@@ -21,7 +21,7 @@ class JellyfinPlaybackProvider(backend.PlaybackProvider):
             item_id = uri.split(':')[-1]
             # Build unique session ID
             letters = string.ascii_letters
-            session_id = ''.join(random.choice(letters) for i in range(20))
+            session_id = ''.join(random.choice(letters) for _ in range(20))
             # List of supported containers
             container = 'opus,mp3,aac,m4a,flac,webma,webm,wav,ogg,mpa,wma'
 

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -97,6 +97,7 @@ class JellyfinHandler(object):
             headers = {'x-mediabrowser-token': token}
             self.http.session.headers.update(headers)
             self._save_token(token)
+            self.token = token
         else:
             logger.error('Unable to login to Jellyfin')
 


### PR DESCRIPTION
It's more recommended to use the `/Audio/{item_id}/universal` endpoint to start an audio stream