### PR TITLE
Don't crash if a reporting session isn't found

### DIFF
--- a/mopidy_jellyfin/frontend.py
+++ b/mopidy_jellyfin/frontend.py
@@ -59,7 +59,11 @@ class EventMonitorFrontend(
         sessions = self.wsc.http.get(
             '{}/Sessions?DeviceId={}'.format(self.hostname, device_id))
 
-        session_id = sessions[0].get('Id')
+        if sessions:
+            session_id = sessions[0].get('Id')
+        else:
+            logger.debug('Unable to find playback session on server')
+            session_id = None
 
         return session_id
 
@@ -115,9 +119,10 @@ class EventMonitorFrontend(
         # Build the json payload sent to the server for playback reporting
 
         session_id = self._get_session_id()
+
         track = self.core.playback.get_current_track().get()
 
-        if track:
+        if session_id and track:
             item_id = track.uri.split(':')[-1]
             mute_state = self.core.mixer.get_mute().get()
             volume = self.core.mixer.get_volume().get()

--- a/mopidy_jellyfin/frontend.py
+++ b/mopidy_jellyfin/frontend.py
@@ -119,7 +119,6 @@ class EventMonitorFrontend(
         # Build the json payload sent to the server for playback reporting
 
         session_id = self._get_session_id()
-
         track = self.core.playback.get_current_track().get()
 
         if session_id and track:


### PR DESCRIPTION
better error handling so the application doesn't crash if playback reporting fails.

Fixes
```
INFO     2020-07-02 10:47:57,171 [391178:Thread-9] mopidy_jellyfin.http
  Jellyfin connection on try 0 with problem: Expecting value: line 1 column 1 (char 0)
ERROR    2020-07-02 10:48:22,352 [391178:MainThread] mopidy.audio.gst
  GStreamer error: Internal data stream error.
INFO     2020-07-02 10:53:34,987 [391178:Thread-9] mopidy_jellyfin.http
  Error parsing Jellyfin data: Expecting value: line 1 column 1 (char 0)
Exception in thread Thread-9:
Traceback (most recent call last):
  File "/usr/lib64/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/matt/Projects/jellyfin/mopidy-jellyfin/mopidy_jellyfin/frontend.py", line 238, in _check_status
    self._update_playback()
  File "/home/matt/Projects/jellyfin/mopidy-jellyfin/mopidy_jellyfin/frontend.py", line 105, in _update_playback
    data = self._create_progress_payload()
  File "/home/matt/Projects/jellyfin/mopidy-jellyfin/mopidy_jellyfin/frontend.py", line 117, in _create_progress_payload
    session_id = self._get_session_id()
  File "/home/matt/Projects/jellyfin/mopidy-jellyfin/mopidy_jellyfin/frontend.py", line 62, in _get_session_id
    session_id = sessions[0].get('Id')
KeyError: 0
```