### PR TITLE
More iris fixes

### DIFF
--- a/mopidy_jellyfin/library.py
+++ b/mopidy_jellyfin/library.py
@@ -22,6 +22,14 @@ class JellyfinLibraryProvider(backend.LibraryProvider):
         # split uri
         parts = uri.split(':')
 
+        # Used for browsing artists in Iris
+        if uri.startswith('jellyfin:artists'):
+            return self.backend.remote.get_artists()
+
+        # Used for browsing albums in Iris
+        if uri.startswith('jellyfin:albums'):
+            return self.backend.remote.get_all_albums()
+
         # move one level lower in directory tree
         if uri.startswith('jellyfin:') and len(parts) == 3:
             item_id = parts[-1]
@@ -56,7 +64,7 @@ class JellyfinLibraryProvider(backend.LibraryProvider):
 
             elif uri.startswith('jellyfin:directory:') or uri == 'jellyfin:':
                 # Prevents weirdness when using Iris, this gets redirected to browse()
-                return None
+                contents = []
 
             else:
                 logger.info('Unknown Jellyfin lookup URI: {}'.format(uri))

--- a/mopidy_jellyfin/library.py
+++ b/mopidy_jellyfin/library.py
@@ -54,12 +54,7 @@ class JellyfinLibraryProvider(backend.LibraryProvider):
 
                 contents = self.backend.remote.lookup_artist(artist_id)
 
-            elif uri.startswith('jellyfin:directory:') and len(parts) ==  3:
-                item_id = parts[-1]
-
-                contents = self.backend.remote.lookup_artist(item_id)
-
-            elif uri == 'jellyfin:':
+            elif uri.startswith('jellyfin:directory:') or uri == 'jellyfin:':
                 # Prevents weirdness when using Iris, this gets redirected to browse()
                 return None
 

--- a/mopidy_jellyfin/library.py
+++ b/mopidy_jellyfin/library.py
@@ -53,6 +53,7 @@ class JellyfinLibraryProvider(backend.LibraryProvider):
                 contents = [
                     self.backend.remote.create_track(track)
                     for track in album_data.get('Items', [])
+                    if track.get('Type') == 'Audio'
                 ]
 
                 contents = sorted(contents, key=lambda k: (k.track_no, k.name))

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -421,6 +421,27 @@ class JellyfinHandler(object):
         return albums
 
     @cache()
+    def get_all_albums(self):
+        url_params = {
+            'UserId': self.user_id,
+            'IncludeItemTypes': 'MusicAlbum',
+            'Recursive': 'true'
+        }
+
+        url = self.api_url('/Items', url_params)
+        albums = self.http.get(url)
+
+        return [
+            models.Ref.album(
+                uri='jellyfin:album:{}'.format(
+                    album.get('Id')
+                ),
+                name=album.get('Name')
+            )
+            for album in albums.get('Items', [])
+        ]
+
+    @cache()
     def get_directory(self, id):
         """Get directory from Jellyfin API.
 

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -488,7 +488,7 @@ class JellyfinHandler(object):
         return models.Track(
             uri='jellyfin:track:{}'.format(track.get('Id')),
             name=track.get('Name'),
-            track_no=track.get('IndexNumber'),
+            track_no=track.get('IndexNumber', 0),
             disc_no=track.get('ParentIndexNumber'),
             genre=','.join(track.get('Genres', [])),
             artists=self.create_artists(track),
@@ -608,7 +608,7 @@ class JellyfinHandler(object):
                 tracks.append(
                     models.Track(
                         uri='jellyfin:track:{}'.format(item.get('ItemId')),
-                        track_no=item.get('IndexNumber'),
+                        track_no=item.get('IndexNumber', 0),
                         name=item.get('Name'),
                         artists=track_artists,
                         album=models.Album(
@@ -719,7 +719,7 @@ class JellyfinHandler(object):
                 if query.get('album'):
                     tracks = [ models.Track(
                         uri='jellyfin:track:{}'.format(track.get('Id')),
-                        track_no=track.get('IndexNumber'),
+                        track_no=track.get('IndexNumber', 0),
                         disc_no=track.get('ParentIndexNumber'),
                         name=track.get('Name'),
                         artists=artist_ref,
@@ -734,7 +734,7 @@ class JellyfinHandler(object):
                 else:
                     tracks = [ models.Track(
                         uri='jellyfin:track:{}'.format(track.get('Id')),
-                        track_no=track.get('IndexNumber'),
+                        track_no=track.get('IndexNumber', 0),
                         disc_no=track.get('ParentIndexNumber'),
                         name=track.get('Name'),
                         artists=artist_ref,
@@ -797,7 +797,7 @@ class JellyfinHandler(object):
             tracks = [
                 models.Track(
                     uri='jellyfin:track:{}'.format(track.get('Id')),
-                    track_no=track.get('IndexNumber'),
+                    track_no=track.get('IndexNumber', 0),
                     disc_no=track.get('ParentIndexNumber'),
                     name=track.get('Name'),
                     artists=artist_ref,
@@ -815,7 +815,7 @@ class JellyfinHandler(object):
             tracks = [
                 models.Track(
                     uri='jellyfin:track:{}'.format(track.get('Id')),
-                    track_no=track.get('IndexNumber'),
+                    track_no=track.get('IndexNumber', 0),
                     name=track.get('Name'),
                     artists=artist_ref,
                     album=models.Album(


### PR DESCRIPTION
Fixes #76 

Also allows using `jellyfin:artists` and `jellyfin:albums` in the custom URI fields of Iris.  (I don't recommend using the albums one.  It seems to take far too long to be useful).

Fixes a few other errors like missing track numbers in the lambda that I ran into in the process