### PR TITLE
Optional flag to show 'watched' status when browsing

### DIFF
--- a/mopidy_jellyfin/__init__.py
+++ b/mopidy_jellyfin/__init__.py
@@ -37,6 +37,7 @@ class Extension(ext.Extension):
         schema['client_key'] = config.String(optional=True)
         schema['album_format'] = config.String(optional=True)
         schema['max_bitrate'] = config.Integer(optional=True)
+        schema['watched_status'] = config.Boolean(optional=True)
 
         return schema
 

--- a/mopidy_jellyfin/ext.conf
+++ b/mopidy_jellyfin/ext.conf
@@ -14,3 +14,5 @@ client_key =
 album_format =
 # Bitrate in kbps
 max_bitrate =
+# Enable watched status on books (default: False)
+watched_status =

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -60,6 +60,7 @@ class JellyfinHandler(object):
                 self.max_bitrate = str(max_bitrate * 1024)
             else:
                 self.max_bitrate = '140000000'
+            self.watched_status = jellyfin.get('watched_status')
             cert = None
             client_cert = jellyfin.get('client_cert', None)
             client_key = jellyfin.get('client_key', None)
@@ -480,9 +481,16 @@ class JellyfinHandler(object):
         :rtype: mopidy.models.Track
         """
         # TODO: add more metadata
+        name = track.get('Name')
+        if self.watched_status and track.get('Type') == 'AudioBook':
+            if track['UserData'].get('PlayCount'):
+                name = f'[X] - {name}'
+            else:
+                name = f'[] - {name}'
+
         return models.Track(
             uri='jellyfin:track:{}'.format(track.get('Id')),
-            name=track.get('Name'),
+            name=name,
             track_no=track.get('IndexNumber', 0),
             disc_no=track.get('ParentIndexNumber'),
             genre=','.join(track.get('Genres', [])),


### PR DESCRIPTION
Adds a new config option to show watched status for AudioBook type tracks.

Renders as either
`[X] - $title`
or
`[] - $title`