### PR TITLE
Refactor and clean up browsing

### DIFF
--- a/mopidy_jellyfin/library.py
+++ b/mopidy_jellyfin/library.py
@@ -25,16 +25,18 @@ class JellyfinLibraryProvider(backend.LibraryProvider):
         # Used for browsing artists in Iris
         if uri.startswith('jellyfin:artists'):
             artists = self.backend.remote.get_all_artists()
-            return self.backend.remote.get_artists_as_ref(artists)
+            return [self.backend.remote.get_artist_as_ref(artist)
+                    for artist in artists]
 
         # Used for browsing albums in Iris
         if uri.startswith('jellyfin:albums'):
-            return self.backend.remote.get_all_albums()
+            albums = self.backend.remote.get_all_albums()
+            return [self.backend.remote.get_album_as_ref(album)
+                    for album in albums]
 
         # move one level lower in directory tree
         if uri.startswith('jellyfin:') and len(parts) == 3:
             item_id = parts[-1]
-            item_type = self.backend.remote.get_item(item_id).get('Type')
             return self.backend.remote.browse_item(item_id)
 
         return []

--- a/mopidy_jellyfin/library.py
+++ b/mopidy_jellyfin/library.py
@@ -24,7 +24,8 @@ class JellyfinLibraryProvider(backend.LibraryProvider):
 
         # Used for browsing artists in Iris
         if uri.startswith('jellyfin:artists'):
-            return self.backend.remote.get_artists()
+            artists = self.backend.remote.get_all_artists()
+            return self.backend.remote.get_artists_as_ref(artists)
 
         # Used for browsing albums in Iris
         if uri.startswith('jellyfin:albums'):
@@ -86,8 +87,10 @@ class JellyfinLibraryProvider(backend.LibraryProvider):
         # Populates Media Library sections (Artists, Albums, etc)
         # Mopidy internally calls search() with exact=True
         if field == 'artist' or field == 'albumartist':
+            artists = self.backend.remote.get_all_artists()
+            artist_refs = self.backend.remote.get_artists_as_ref(artists)
             return [
-                artist.name for artist in self.backend.remote.get_artists()
+                artist.name for artist in artist_refs
             ]
         elif field == 'album':
             return [

--- a/mopidy_jellyfin/library.py
+++ b/mopidy_jellyfin/library.py
@@ -88,12 +88,8 @@ class JellyfinLibraryProvider(backend.LibraryProvider):
         # Mopidy internally calls search() with exact=True
         if field == 'artist' or field == 'albumartist':
             artists = self.backend.remote.get_all_artists()
-            artist_refs = self.backend.remote.get_artists_as_ref(artists)
-            return [
-                artist.name for artist in artist_refs
-            ]
+            return [ artist.get('Name') for artist in artists ]
         elif field == 'album':
-            return [
-                album.name for album in self.backend.remote.get_albums(query)
-            ]
+            albums = self.backend.remote.get_albums(query)
+            return [album.get('Name') for album in albums]
         return []

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -749,9 +749,9 @@ class JellyfinHandler(object):
             for album in album_data:
                 if album.get('Name') == album_name:
                     album_obj = models.Album(
-                        name=item.get('Name'),
-                        artists=self.create_artists(item),
-                        uri='jellyfin:album:{}'.format(item.get('Id'))
+                        name=album.get('Name'),
+                        artists=self.create_artists(album),
+                        uri='jellyfin:album:{}'.format(album.get('Id'))
                     )
                     if album_obj not in albums:
                         albums.append(album_obj)

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -317,8 +317,9 @@ class JellyfinHandler(object):
             contents = self.get_directory(item_id).get('Items')
             ret_value = []
 
+            # Create an entry for each item depending on it's type
             for item in contents:
-                if item.get('Type') in ('Audio', 'Audiobok'):
+                if item.get('Type') in ('Audio', 'AudioBook'):
                     # Create tracks
                     ret_value.append(self.get_track_as_ref(item))
                 elif item.get('Type') == 'MusicArtist':
@@ -475,12 +476,9 @@ class JellyfinHandler(object):
         }
 
         url = self.api_url('/Items', url_params)
-        albums = self.http.get(url)
+        albums = self.http.get(url).get('Items')
 
-        return [
-            self.get_album_as_ref(album)
-            for album in albums.get('Items', [])
-        ]
+        return albums
 
     @cache()
     def get_directory(self, id):

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -457,12 +457,7 @@ class JellyfinHandler(object):
         url = self.api_url('/Items', url_params)
         result = self.http.get(url)
         if result:
-            raw_albums = result.get('Items')
-
-        albums = [
-            self.create_album(item)
-            for item in raw_albums
-        ]
+            albums = result.get('Items')
 
         return albums
 
@@ -742,7 +737,6 @@ class JellyfinHandler(object):
                     'IncludeItemTypes': 'MusicAlbum',
                     'IncludeMedia': 'true',
                     'Recursive': 'true',
-                    'UserId': self.user_id,
                     'searchTerm': album_name
                 }
                 url = self.api_url('/Users/{}/Items'.format(self.user_id), url_params)

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -735,7 +735,6 @@ class JellyfinHandler(object):
         # Use if query only has an album name
         elif 'album' in query:
             album_name = query.get('album')[0]
-            album = quote(album_name.encode('utf8'))
             url_params = {
                 'IncludeItemTypes': 'MusicAlbum',
                 'IncludeMedia': 'true',

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -421,7 +421,6 @@ class JellyfinHandler(object):
     @cache()
     def get_albums(self, query):
         raw_artist = [""]
-        raw_albums = []
 
         # Check query for artist name
         if 'artist' in query:
@@ -704,7 +703,6 @@ class JellyfinHandler(object):
                 contents = album_data.get('Items')
                 for item in contents:
                     if item.get('Type') == 'MusicAlbum':
-                        #album_obj = self.create_album(item)
                         album_obj = models.Album(
                             name=item.get('Name'),
                             artists=self.create_artists(item),


### PR DESCRIPTION
_Should_ fix #18 

* Changes the browse functionality to correctly pull Artists from the server instead of raw items based on ParentId.  This has the effect of always pulling artists instead of having albums mixed in when the file structure is bad (see https://github.com/jellyfin/jellyfin/issues/3962 and conversation in #18).
* Adds a bunch of very high level comments to functions
* Removes some duplicate code, particularly around defining `url_params` and translating items to mopidy objects (`models.Ref.xxx`)
* Changes the api call done when searching for an album name and nothing else.  This call was frequently timing out when using MALP before.

maybe one or two other things I forgot about.  This grew into more than I was planning