### PR TITLE
Fallback to 0 if runtimeticks value isn't found

### DIFF
--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -533,7 +533,7 @@ class JellyfinHandler(object):
             genre=','.join(track.get('Genres', [])),
             artists=self.create_artists(track=track),
             album=self.create_album(track),
-            length=self.ticks_to_milliseconds(track.get('RunTimeTicks'))
+            length=self.ticks_to_milliseconds(track.get('RunTimeTicks', 0))
         )
 
     def create_album(self, track):


### PR DESCRIPTION
Should fix #71.  I've only seen it myself once and haven't been able to reproduce it, but in theory this will prevent that.