### PR TITLE
Support incremental volume up/down commands

### DIFF
--- a/mopidy_jellyfin/frontend.py
+++ b/mopidy_jellyfin/frontend.py
@@ -198,7 +198,7 @@ class EventMonitorFrontend(
             self.core.mixer.set_volume(int(volume))
         elif command == 'VolumeUp' or command == 'VolumeDown':
             vol = self.core.mixer.get_volume().get()
-            increment = -1 if command == 'VolumeDown' else 1
+            increment = -5 if command == 'VolumeDown' else 5
             self.core.mixer.set_volume(vol + increment)
         elif command == 'ToggleMute':
             if self.core.mixer.get_mute().get():

--- a/mopidy_jellyfin/frontend.py
+++ b/mopidy_jellyfin/frontend.py
@@ -196,6 +196,10 @@ class EventMonitorFrontend(
         if command == 'SetVolume':
             volume = data['Arguments'].get('Volume')
             self.core.mixer.set_volume(int(volume))
+        elif command == 'VolumeUp' or command == 'VolumeDown':
+            vol = self.core.mixer.get_volume().get()
+            increment = -1 if command == 'VolumeDown' else 1
+            self.core.mixer.set_volume(vol + increment)
         elif command == 'ToggleMute':
             if self.core.mixer.get_mute().get():
                 self.core.mixer.set_mute(False)


### PR DESCRIPTION
This PR allows Mopidy-Jellyfin to respond to volume rocker button presses on some Android phones which end up sending VolumeUp/VolumeDown commands from Jellyfin server instead of SetVolume (which is rather triggered when touching the Volume slider on the phone).

Thank you for your work!