### PR TITLE
Do no additional quoting for search term

### DIFF
--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -683,7 +683,7 @@ class JellyfinHandler(object):
             raise Exception('Jellyfin search: no itemtype {}'.format(itemtype))
 
         url_params = {
-            'SearchTerm': quote(term.encode('utf-8')),
+            'SearchTerm': term,
             'IncludeItemTypes': search_query
         }
 


### PR DESCRIPTION
This fixes #134 and possibly other issues caused by URL encoding search term twice.