### PR TITLE
Place a limit on the json body for now playing api calls

### DIFF
--- a/mopidy_jellyfin/frontend.py
+++ b/mopidy_jellyfin/frontend.py
@@ -148,6 +148,10 @@ class EventMonitorFrontend(
                     'Id': track_id,
                     'PlaylistItemId': f'playlistItem{index}'
                 })
+                # Max json body in the server for play queue is 1000
+                # This gives us a little wiggle room
+                if index >= 950:
+                    break
             playlist_item_id = f'playlistItem{track_index}'
 
             # json payload to server


### PR DESCRIPTION
There's a max size of 1000 in for the json body when reporting playback status to the server.  This allows us to have larger play queues locally, but only reports the first 950 items to prevent errors and gives a little bit of head room.