### PR TITLE
Fix crash when track number is -1

### DIFF
--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -583,7 +583,7 @@ class JellyfinHandler(object):
             uri='jellyfin:track:{}'.format(track.get('Id')),
             name=name,
             bitrate=bitrate,
-            track_no=track.get('IndexNumber', 0),
+            track_no=track.get('IndexNumber', 0) if track.get('IndexNumber', 0) >= 0 else 0,
             disc_no=track.get('ParentIndexNumber'),
             genre=','.join(track.get('Genres', [])),
             artists=self.create_artists(track),


### PR DESCRIPTION
I got this error:

```
Jan 16 15:08:09 sre mopidy[77098]: ERROR    2025-01-16 15:08:09,162 [77098:MainThread] mopidy.commands
Jan 16 15:08:09 sre mopidy[77098]:   Got un-handled exception from JellyfinBackend
Jan 16 15:08:09 sre mopidy[77098]: Traceback (most recent call last):
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy/commands.py", line 248, in _actor_error_handling
Jan 16 15:08:09 sre mopidy[77098]:     yield
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy/commands.py", line 412, in start_backends
Jan 16 15:08:09 sre mopidy[77098]:     backend = backend_class.start(
Jan 16 15:08:09 sre mopidy[77098]:               ^^^^^^^^^^^^^^^^^^^^
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/pykka/_actor.py", line 117, in start
Jan 16 15:08:09 sre mopidy[77098]:     obj = cls(*args, **kwargs)
Jan 16 15:08:09 sre mopidy[77098]:           ^^^^^^^^^^^^^^^^^^^^
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy_jellyfin/backend.py", line 27, in __init__
Jan 16 15:08:09 sre mopidy[77098]:     self.playlists = JellyfinPlaylistsProvider(backend=self)
Jan 16 15:08:09 sre mopidy[77098]:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy_jellyfin/playlists.py", line 17, in __init__
Jan 16 15:08:09 sre mopidy[77098]:     self.refresh()
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy_jellyfin/playlists.py", line 69, in refresh
Jan 16 15:08:09 sre mopidy[77098]:     self.backend.remote.create_track(track)
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy_jellyfin/remote.py", line 582, in create_track
Jan 16 15:08:09 sre mopidy[77098]:     return models.Track(
Jan 16 15:08:09 sre mopidy[77098]:            ^^^^^^^^^^^^^
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy/models/immutable.py", line 159, in __call__
Jan 16 15:08:09 sre mopidy[77098]:     instance = super().__call__(*args, **kwargs)
Jan 16 15:08:09 sre mopidy[77098]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy/models/immutable.py", line 35, in __init__
Jan 16 15:08:09 sre mopidy[77098]:     self._set_field(key, value)
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy/models/immutable.py", line 188, in _set_field
Jan 16 15:08:09 sre mopidy[77098]:     object.__setattr__(self, name, value)
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy/models/fields.py", line 50, in __set__
Jan 16 15:08:09 sre mopidy[77098]:     value = self.validate(value)
Jan 16 15:08:09 sre mopidy[77098]:             ^^^^^^^^^^^^^^^^^^^^
Jan 16 15:08:09 sre mopidy[77098]:   File "/usr/lib/python3.12/site-packages/mopidy/models/fields.py", line 135, in validate
Jan 16 15:08:09 sre mopidy[77098]:     raise ValueError(
Jan 16 15:08:09 sre mopidy[77098]: ValueError: Expected track_no to be at least 0, not -1
```

Apparently, I've a mp3 file with the track number set to `-1`. This isn't a problem for Jellyfin, but mopidy-jellyfin crashes.