### PR TITLE
Additional users to session

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Mopidy-Jellyfin to your Mopidy configuration file::
     album_format = {ProductionYear} - {Name} (Optional: will default to "{Name}" if left undefined)
     max_bitrate = number
     friendly_name = name (Optional: An alternative name to display in Jellyfin)
+    additional_users = username2,username3 (Optional: Comma seperated list of users added to the session)
 
 * ``libraries`` determines what is populated into Mopidy's internal library (view by Artists/Album/etc).  Using the file browser will show all libraries in the Jellyfin server that have a 'music' type.
 

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ Mopidy-Jellyfin to your Mopidy configuration file::
     albumartistsort = False (Optional: will default to True if left undefined)
     album_format = {ProductionYear} - {Name} (Optional: will default to "{Name}" if left undefined)
     max_bitrate = number
+    friendly_name = name (Optional: An alternative name to display in Jellyfin)
 
 * ``libraries`` determines what is populated into Mopidy's internal library (view by Artists/Album/etc).  Using the file browser will show all libraries in the Jellyfin server that have a 'music' type.
 

--- a/mopidy_jellyfin/__init__.py
+++ b/mopidy_jellyfin/__init__.py
@@ -39,6 +39,7 @@ class Extension(ext.Extension):
         schema['album_format'] = config.String(optional=True)
         schema['max_bitrate'] = config.Integer(optional=True)
         schema['watched_status'] = config.Boolean(optional=True)
+        schema['friendly_name'] = config.String(optional=True)
 
         return schema
 

--- a/mopidy_jellyfin/__init__.py
+++ b/mopidy_jellyfin/__init__.py
@@ -40,6 +40,7 @@ class Extension(ext.Extension):
         schema['max_bitrate'] = config.Integer(optional=True)
         schema['watched_status'] = config.Boolean(optional=True)
         schema['friendly_name'] = config.String(optional=True)
+        schema['additional_users'] = config.String(optional=True)
 
         return schema
 

--- a/mopidy_jellyfin/ext.conf
+++ b/mopidy_jellyfin/ext.conf
@@ -17,3 +17,5 @@ album_format =
 max_bitrate =
 # Enable watched status on books (default: False)
 watched_status =
+# Alternative name instead of hostname, for casting
+friendly_name =

--- a/mopidy_jellyfin/ext.conf
+++ b/mopidy_jellyfin/ext.conf
@@ -19,3 +19,5 @@ max_bitrate =
 watched_status =
 # Alternative name instead of hostname, for casting
 friendly_name =
+# Add additional users to the session, seperated by ,
+additional_users =

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -54,6 +54,9 @@ class JellyfinHandler(object):
         else:
             self.max_bitrate = '140000000'
         self.watched_status = jellyfin.get('watched_status')
+        friendly_name = jellyfin.get('friendly_name')
+        if friendly_name:
+            mopidy_jellyfin.Extension.device_name = friendly_name
         cert = None
         client_cert = jellyfin.get('client_cert', None)
         client_key = jellyfin.get('client_key', None)


### PR DESCRIPTION
This pull request adds support for adding additional users to a session, allowing them to cast to the Mopidy client. Additionally, it introduces an option to set a custom name for a client instead of using the default hostname.

During testing, I found that this feature does not work when authenticating with a token, you must use a username and password. Based on my reading of the documentation, it doesn't seem possible to initiate a session without a username and password (though I'd love to be proven wrong!).

For reference, this limitation already exists in the current version: the casting feature does not work when logging in with a token.