### PR TITLE
fix(core): Fixes compatibility with Mopidy >= 4.0

### DIFF
--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -245,7 +245,7 @@ class JellyfinHandler(object):
         elif curr_length > new_length:
             # If the new playlist is shorter than the old, delete tracks
             self.delete_from_playlist(playlist_id, curr_tracks, new_ids)
-        elif curr_length < new_length:
+        else:
             # If the new playlist is longer than the old, add new tracks
             self.add_to_playlist(playlist_id, curr_tracks, new_ids)
 
@@ -685,7 +685,7 @@ class JellyfinHandler(object):
         url = self.api_url('/Search/Hints', url_params)
         data = self.http.get(url)
 
-        return [i for i in data.get('SearchHints', [])]
+        return list(data.get('SearchHints', []))
 
     @cache()
     def search(self, query):

--- a/mopidy_jellyfin/remote.py
+++ b/mopidy_jellyfin/remote.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from mopidy import httpclient, models
+from mopidy import models
 from mopidy_jellyfin.utils import cache
 import mopidy_jellyfin
 from .http import JellyfinHttpClient
@@ -9,19 +9,13 @@ import os
 import logging
 from collections import OrderedDict, defaultdict
 import sys
-if sys.version.startswith('3'):
-    from urllib.parse import (
-        parse_qs,
-        quote,
-        urlencode,
-        urljoin,
-        urlsplit,
-        urlunsplit
-    )
+
+if sys.version.startswith("3"):
+    from urllib.parse import parse_qs, quote, urlencode, urlsplit, urlunsplit
 else:
     from urllib import urlencode
     from urllib2 import quote
-    from urlparse import parse_qs, urljoin, urlsplit, urlunsplit
+    from urlparse import parse_qs, urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
@@ -29,39 +23,39 @@ logger = logging.getLogger(__name__)
 class JellyfinHandler(object):
     def __init__(self, config):
         self.config = config
-        proxy = config.get('proxy')
-        jellyfin = config.get('jellyfin')
-        self.hostname = jellyfin.get('hostname')
-        self.hostname = self.hostname.strip('/')
-        self.username = jellyfin.get('username')
-        self.password = jellyfin.get('password', '')
-        self.user_id = jellyfin.get('user_id')
-        self.token = jellyfin.get('token')
-        self.libraries = jellyfin.get('libraries')
+        proxy = config.get("proxy")
+        jellyfin = config.get("jellyfin")
+        self.hostname = jellyfin.get("hostname")
+        self.hostname = self.hostname.strip("/")
+        self.username = jellyfin.get("username")
+        self.password = jellyfin.get("password", "")
+        self.user_id = jellyfin.get("user_id")
+        self.token = jellyfin.get("token")
+        self.libraries = jellyfin.get("libraries")
         # If no libraries are provided, default to 'Music'
         if not self.libraries:
-            self.libraries = 'Music'
-        self.albumartistsort = jellyfin.get('albumartistsort')
+            self.libraries = "Music"
+        self.albumartistsort = jellyfin.get("albumartistsort")
         # If not overridden, default to using Album Artist sort method
         # This _really_ shouldn't be necessary, but it is for reasons
-        if self.albumartistsort not in ['False', 'false']:
+        if self.albumartistsort not in ["False", "false"]:
             self.albumartistsort = True
         else:
             self.albumartistsort = False
-        max_bitrate = jellyfin.get('max_bitrate')
+        max_bitrate = jellyfin.get("max_bitrate")
         if max_bitrate:
             self.max_bitrate = str(max_bitrate * 1024)
         else:
-            self.max_bitrate = '140000000'
-        self.watched_status = jellyfin.get('watched_status')
+            self.max_bitrate = "140000000"
+        self.watched_status = jellyfin.get("watched_status")
         cert = None
-        client_cert = jellyfin.get('client_cert', None)
-        client_key = jellyfin.get('client_key', None)
+        client_cert = jellyfin.get("client_cert", None)
+        client_key = jellyfin.get("client_key", None)
         if client_cert is not None and client_key is not None:
             cert = (client_cert, client_key)
-        self.album_format = jellyfin.get('album_format', False)
+        self.album_format = jellyfin.get("album_format", False)
         if not self.album_format:
-            self.album_format = '{Name}'
+            self.album_format = "{Name}"
 
         # create authentication headers
         self.auth_data = self._auth_payload()
@@ -75,47 +69,40 @@ class JellyfinHandler(object):
             self._login()
 
         if self.token:
-           self.http.session.headers.update({'x-mediabrowser-token': self.token})
+            self.http.session.headers.update({"x-mediabrowser-token": self.token})
+
     def _save_token(self, token):
         # Save the authentication token where the frontend can also access it
         cache_dir = mopidy_jellyfin.Extension.get_cache_dir(self.config)
-        token_file = os.path.join(cache_dir, 'token')
+        token_file = os.path.join(cache_dir, "token")
 
-        with open(token_file, 'w') as f:
+        with open(token_file, "w") as f:
             f.write(token)
 
     def _login(self):
-        """Return token for a user.
-        """
-        url = self.api_url('/Users/AuthenticateByName')
-        auth_details = self.http.post(
-                url, self.auth_data)
+        """Return token for a user."""
+        url = self.api_url("/Users/AuthenticateByName")
+        auth_details = self.http.post(url, self.auth_data)
 
-        token = auth_details.get('AccessToken')
+        token = auth_details.get("AccessToken")
 
         if token:
-            self.user_id = auth_details.get('User').get('Id')
+            self.user_id = auth_details.get("User").get("Id")
             self._save_token(token)
             self.token = token
         else:
-            logger.error('Unable to login to Jellyfin')
-
+            logger.error("Unable to login to Jellyfin")
 
     def _auth_payload(self):
-        """Returns a dict with username and password.
-        """
-        return {
-            'username': self.username,
-            'Pw': self.password
-        }
+        """Returns a dict with username and password."""
+        return {"username": self.username, "Pw": self.password}
 
     def _create_headers(self, token=None):
-        """Return header dict that is needed to talk to the Jellyfin API.
-        """
+        """Return header dict that is needed to talk to the Jellyfin API."""
         headers = {}
 
         authorization = (
-            'MediaBrowser , '
+            "MediaBrowser , "
             'Client="Mopidy", '
             'Device="{device}", '
             'DeviceId="{device_id}", '
@@ -123,13 +110,13 @@ class JellyfinHandler(object):
         ).format(
             device=mopidy_jellyfin.Extension.device_name,
             device_id=mopidy_jellyfin.Extension.device_id,
-            version=mopidy_jellyfin.__version__
+            version=mopidy_jellyfin.__version__,
         )
 
-        headers['x-emby-authorization'] = authorization
+        headers["x-emby-authorization"] = authorization
 
         if token:
-            headers['x-mediabrowser-token'] = self.token
+            headers["x-mediabrowser-token"] = self.token
 
         return headers
 
@@ -143,92 +130,88 @@ class JellyfinHandler(object):
         query_params = parse_qs(query_string)
         path = path + endpoint
 
-        query_params['format'] = 'json'
+        query_params["format"] = "json"
         query_params.update(url_params)
         new_query_string = urlencode(query_params, doseq=True)
 
         return urlunsplit((scheme, netloc, path, new_query_string, fragment))
 
     def get_music_root(self):
-        url = self.api_url(
-            '/Users/{}/Views'.format(self.user_id)
-        )
+        url = self.api_url("/Users/{}/Views".format(self.user_id))
 
         data = self.http.get(url)
 
         media_folders = [
-            {'Name': library.get('Name'),
-             'Id': library.get('Id'),
-             'CollectionType': library.get('CollectionType')}
-            for library in data.get('Items')
-            if library.get('CollectionType') in ['books', 'music']
+            {
+                "Name": library.get("Name"),
+                "Id": library.get("Id"),
+                "CollectionType": library.get("CollectionType"),
+            }
+            for library in data.get("Items")
+            if library.get("CollectionType") in ["books", "music"]
         ]
 
         if media_folders:
-            logging.debug('Jellyfin: Found libraries')
+            logging.debug("Jellyfin: Found libraries")
             return media_folders
 
         else:
             logging.debug(
-                'Jellyfin: All directories found: {}'.format(
-                    [i.get('CollectionType')
-                     for i in data.get('Items')
-                     if 'CollectionType' in i.items()]
+                "Jellyfin: All directories found: {}".format(
+                    [
+                        i.get("CollectionType")
+                        for i in data.get("Items")
+                        if "CollectionType" in i.items()
+                    ]
                 )
             )
-            raise Exception('Jellyfin: Cant find music root directory')
+            raise Exception("Jellyfin: Cant find music root directory")
 
     def get_library_roots(self):
         libraries = self.get_music_root()
 
         return [
             models.Ref.directory(
-                uri='jellyfin:directory:{}'.format(i.get('Id')),
-                name=i.get('Name')
-            ) for i in libraries if i
+                uri="jellyfin:directory:{}".format(i.get("Id")), name=i.get("Name")
+            )
+            for i in libraries
+            if i
         ]
 
     def get_playlists(self):
-        '''
+        """
         Queries the server for any playlist objects
-        '''
+        """
         url_params = {
-            'UserId': self.user_id,
-            'IncludeItemTypes': 'Playlist',
-            'Recursive': 'true',
-            'fields': 'MediaSources'
+            "UserId": self.user_id,
+            "IncludeItemTypes": "Playlist",
+            "Recursive": "true",
+            "fields": "MediaSources",
         }
 
-        url = self.api_url('/Users/{}/Items'.format(self.user_id), url_params)
+        url = self.api_url("/Users/{}/Items".format(self.user_id), url_params)
         playlists = self.http.get(url)
 
-        return playlists.get('Items', [])
+        return playlists.get("Items", [])
 
     def get_playlist_contents(self, playlist_id):
-        url_params = {
-            'UserId': self.user_id,
-            'fields': 'MediaSources'
-        }
-        url = self.api_url('/Playlists/{}/Items'.format(playlist_id), url_params)
+        url_params = {"UserId": self.user_id, "fields": "MediaSources"}
+        url = self.api_url("/Playlists/{}/Items".format(playlist_id), url_params)
 
-        data = self.http.get(url).get('Items', [])
+        data = self.http.get(url).get("Items", [])
 
         return data
 
     def create_playlist(self, name):
-        url = self.api_url('/Playlists')
+        url = self.api_url("/Playlists")
 
-        payload = {
-            'Name': name,
-            'UserId': self.user_id,
-            'MediaType': 'Audio'
-        }
+        payload = {"Name": name, "UserId": self.user_id, "MediaType": "Audio"}
 
         return self.http.post(url, payload)
 
     def delete_playlist(self, playlist_id):
-        url_params = { 'UserId': self.user_id }
-        url = self.api_url('/Items/{}'.format(playlist_id), url_params)
+        url_params = {"UserId": self.user_id}
+        url = self.api_url("/Items/{}".format(playlist_id), url_params)
 
         result = self.http.delete(url)
         return result.ok
@@ -251,126 +234,117 @@ class JellyfinHandler(object):
 
     def move_playlist_items(self, playlist_id, curr_tracks, new_ids):
         # Loop through the current and new list, finding the moved track
-        for index,item in enumerate(curr_tracks, 0):
-            if item['Id'] != new_ids[index]:
-                new_index = new_ids.index(item['Id'])
+        for index, item in enumerate(curr_tracks, 0):
+            if item["Id"] != new_ids[index]:
+                new_index = new_ids.index(item["Id"])
                 # If an item has only moved down 1 slot, it was likely caused
                 # by another track being moved above it
                 if new_index - index != 1:
                     break
 
         # Playlists have their own unique item IDs
-        item_id = item['PlaylistItemId']
+        item_id = item["PlaylistItemId"]
 
-        url = self.api_url(f'/Playlists/{playlist_id}/Items/{item_id}/Move/{new_index}')
+        url = self.api_url(f"/Playlists/{playlist_id}/Items/{item_id}/Move/{new_index}")
         self.http.post(url)
 
     def delete_from_playlist(self, playlist_id, curr_tracks, new_ids):
-        curr_ids = [ track['Id'] for track in curr_tracks ]
+        curr_ids = [track["Id"] for track in curr_tracks]
 
         # Find items that are in the old playlist but missing from the new one
         del_items = list(set(curr_ids) - set(new_ids))
 
         # Get the PlaylistItemId of each track to be deleted
-        del_ids = [ track['PlaylistItemId'] for track in curr_tracks if track['Id'] in del_items ]
+        del_ids = [
+            track["PlaylistItemId"] for track in curr_tracks if track["Id"] in del_items
+        ]
 
-        url_params = {
-            'UserId': self.user_id,
-            'EntryIds': ','.join(del_ids)
-        }
-        del_url = self.api_url(f'Playlists/{playlist_id}/Items', url_params)
+        url_params = {"UserId": self.user_id, "EntryIds": ",".join(del_ids)}
+        del_url = self.api_url(f"Playlists/{playlist_id}/Items", url_params)
         self.http.delete(del_url)
 
     def add_to_playlist(self, playlist_id, curr_tracks, new_ids):
-        curr_ids = [ track['Id'] for track in curr_tracks ]
+        curr_ids = [track["Id"] for track in curr_tracks]
 
         # Find items in the new playlist that are missing from the old one
         add_ids = list(set(new_ids) - set(curr_ids))
 
-        url_params = {
-            'UserId': self.user_id,
-            'Ids': ','.join(add_ids)
-        }
-        new_url = self.api_url(f'/Playlists/{playlist_id}/Items', url_params)
+        url_params = {"UserId": self.user_id, "Ids": ",".join(add_ids)}
+        new_url = self.api_url(f"/Playlists/{playlist_id}/Items", url_params)
         self.http.post(new_url)
 
     def get_favorites(self):
-        '''
+        """
         Pulls a list of favorite audio related content from the server and
         build playlists from it
-        '''
+        """
 
         # Types of playlists to build
-        playlists = {
-            'All': [],
-            'Tracks': [],
-            'Albums': [],
-            'Artists': []
-        }
+        playlists = {"All": [], "Tracks": [], "Albums": [], "Artists": []}
 
         url_params = {
-            'Recursive': 'true',
-            'Filters': 'IsFavorite',
-            'fields': 'MediaSources'
+            "Recursive": "true",
+            "Filters": "IsFavorite",
+            "fields": "MediaSources",
         }
 
-        fav_items_url = self.api_url(f'/Users/{self.user_id}/Items', url_params)
-        fav_items = self.http.get(fav_items_url).get('Items', [])
+        fav_items_url = self.api_url(f"/Users/{self.user_id}/Items", url_params)
+        fav_items = self.http.get(fav_items_url).get("Items", [])
 
         for item in fav_items:
-            item_type = item.get('Type')
-            if item_type == 'Audio':
-                playlists['Tracks'].append(self.create_track(item))
-            elif item_type == 'MusicAlbum':
+            item_type = item.get("Type")
+            if item_type == "Audio":
+                playlists["Tracks"].append(self.create_track(item))
+            elif item_type == "MusicAlbum":
                 # Get tracks from the favorited album
-                tracks = self.get_directory(item.get('Id')).get('Items', [])
-                playlists['Albums'].extend([
-                    self.create_track(track) for track in tracks])
+                tracks = self.get_directory(item.get("Id")).get("Items", [])
+                playlists["Albums"].extend(
+                    [self.create_track(track) for track in tracks]
+                )
 
         # User ID needed for the artists query
-        url_params['UserId'] = self.user_id
+        url_params["UserId"] = self.user_id
 
         # Artists aren't available in the previous call and have to be separate
-        fav_artists_url = self.api_url(f'/Artists', url_params)
-        fav_artists = self.http.get(fav_artists_url).get('Items', [])
+        fav_artists_url = self.api_url(f"/Artists", url_params)
+        fav_artists = self.http.get(fav_artists_url).get("Items", [])
 
         for artist in fav_artists:
             # Get tracks from the favorited artist
-            artist_id = artist.get('Id')
-            playlists['Artists'].extend(self.lookup_artist(artist_id))
+            artist_id = artist.get("Id")
+            playlists["Artists"].extend(self.lookup_artist(artist_id))
 
         # 'All' should include the other 3 lists combined
-        playlists['All'].extend(playlists['Tracks'])
-        playlists['All'].extend(playlists['Albums'])
-        playlists['All'].extend(playlists['Artists'])
+        playlists["All"].extend(playlists["Tracks"])
+        playlists["All"].extend(playlists["Albums"])
+        playlists["All"].extend(playlists["Artists"])
 
         return playlists
-
 
     @cache()
     def browse_item(self, item_id):
         item = self.get_item(item_id)
-        if item.get('CollectionType', '') == 'music':
+        if item.get("CollectionType", "") == "music":
             # Pull all artists for this library
             artists = self.get_library_artists(item_id)
             ret_value = [self.get_artist_as_ref(artist) for artist in artists]
-        elif item.get('Type', '') == 'MusicArtist':
+        elif item.get("Type", "") == "MusicArtist":
             # Pull list of albums for a given artist
             ret_value = self.get_artist_contents(item_id)
         else:
             # Browse the directory tree
-            contents = self.get_directory(item_id).get('Items')
+            contents = self.get_directory(item_id).get("Items")
             ret_value = []
 
             # Create an entry for each item depending on it's type
             for item in contents:
-                if item.get('Type') in ('Audio', 'AudioBook'):
+                if item.get("Type") in ("Audio", "AudioBook"):
                     # Create tracks
                     ret_value.append(self.get_track_as_ref(item))
-                elif item.get('Type') == 'MusicArtist':
+                elif item.get("Type") == "MusicArtist":
                     # Create artists (probably never used)
                     ret_value.append(self.get_artist_as_ref(item))
-                elif item.get('Type') in ('MusicAlbum', 'Folder'):
+                elif item.get("Type") in ("MusicAlbum", "Folder"):
                     # Create browsable folders
                     ret_value.append(self.get_album_as_ref(item))
 
@@ -384,8 +358,8 @@ class JellyfinHandler(object):
 
         for library in libraries:
 
-            if library.get('Name') in self.libraries:
-                library_id = library.get('Id')
+            if library.get("Name") in self.libraries:
+                library_id = library.get("Id")
                 artists += self.get_library_artists(library_id)
 
         return artists
@@ -398,20 +372,20 @@ class JellyfinHandler(object):
 
         # Get album list
         url_params = {
-            'UserId': self.user_id,
-            'IncludeItemTypes': 'MusicAlbum',
-            'Recursive': 'true',
-            'fields': 'MediaSources'
+            "UserId": self.user_id,
+            "IncludeItemTypes": "MusicAlbum",
+            "Recursive": "true",
+            "fields": "MediaSources",
         }
         if self.albumartistsort:
-            url_params['AlbumArtistIds'] = artist_id
+            url_params["AlbumArtistIds"] = artist_id
         else:
-            url_params['ArtistIds'] = artist_id
+            url_params["ArtistIds"] = artist_id
 
-        url = self.api_url('/Items', url_params)
+        url = self.api_url("/Items", url_params)
         result = self.http.get(url)
         if result:
-            contents = result.get('Items')
+            contents = result.get("Items")
 
         ret_val = [self.get_album_as_ref(album) for album in contents]
 
@@ -420,16 +394,13 @@ class JellyfinHandler(object):
     @cache()
     def get_library_artists(self, library_id):
         # Get a list of all artists in the given library
-        url_params = {
-            'ParentId': library_id,
-            'UserId': self.user_id
-        }
+        url_params = {"ParentId": library_id, "UserId": self.user_id}
         if self.albumartistsort:
-            url = self.api_url('/Artists/AlbumArtists', url_params)
+            url = self.api_url("/Artists/AlbumArtists", url_params)
         else:
-            url = self.api_url('/Artists', url_params)
+            url = self.api_url("/Artists", url_params)
 
-        artists = self.http.get(url).get('Items')
+        artists = self.http.get(url).get("Items")
 
         return artists
 
@@ -437,10 +408,7 @@ class JellyfinHandler(object):
     def get_artist_as_ref(self, artist):
         # Convert artist into mopidy object
         artist_ref = models.Ref.artist(
-            uri='jellyfin:artist:{}'.format(
-                artist.get('Id')
-            ),
-            name=artist.get('Name')
+            uri="jellyfin:artist:{}".format(artist.get("Id")), name=artist.get("Name")
         )
 
         return artist_ref
@@ -449,58 +417,51 @@ class JellyfinHandler(object):
     def get_album_as_ref(self, album):
         # Convert album into mopidy object
         return models.Ref.album(
-            uri='jellyfin:album:{}'.format(
-                album.get('Id')
-            ),
-            name=self.format_album(album)
+            uri="jellyfin:album:{}".format(album.get("Id")),
+            name=self.format_album(album),
         )
 
     def get_track_as_ref(self, track):
         # Convert track into mopidy object
         return models.Ref.track(
-            uri='jellyfin:track:{}'.format(
-                track.get('Id')
-            ),
-            name=track.get('Name')
+            uri="jellyfin:track:{}".format(track.get("Id")), name=track.get("Name")
         )
 
     @cache()
     def get_albums(self, query):
         # Check query for artist name
-        if 'artist' in query:
-            raw_artist = query.get('artist')
-        elif 'albumartist' in query:
-            raw_artist = query.get('albumartist')
+        if "artist" in query:
+            raw_artist = query.get("artist")
+        elif "albumartist" in query:
+            raw_artist = query.get("albumartist")
         else:
             return []
 
         # URL encode artist string
-        artist = quote(raw_artist[0].encode('utf8')).replace('/', '-')
-        url_params= {
-            'UserId': self.user_id
-        }
-        url = self.api_url('/Artists/{}'.format(artist), url_params)
+        artist = quote(raw_artist[0].encode("utf8")).replace("/", "-")
+        url_params = {"UserId": self.user_id}
+        url = self.api_url("/Artists/{}".format(artist), url_params)
 
         # Pull out artist_id
         artist_data = self.http.get(url)
-        artist_id = artist_data.get('Id')
+        artist_id = artist_data.get("Id")
 
         url_params = {
-            'UserId': self.user_id,
-            'IncludeItemTypes': 'MusicAlbum',
-            'Recursive': 'true'
+            "UserId": self.user_id,
+            "IncludeItemTypes": "MusicAlbum",
+            "Recursive": "true",
         }
 
         # Get album list
         if self.albumartistsort:
-            url_params['AlbumArtistIds'] = artist_id
+            url_params["AlbumArtistIds"] = artist_id
         else:
-            url_params['ArtistIds'] = artist_id
+            url_params["ArtistIds"] = artist_id
 
-        url = self.api_url('/Items', url_params)
+        url = self.api_url("/Items", url_params)
         result = self.http.get(url)
         if result:
-            albums = result.get('Items')
+            albums = result.get("Items")
 
         return albums
 
@@ -508,13 +469,13 @@ class JellyfinHandler(object):
     def get_all_albums(self):
         # Get a list of all albums in the library.  Used for mopidy-iris
         url_params = {
-            'UserId': self.user_id,
-            'IncludeItemTypes': 'MusicAlbum',
-            'Recursive': 'true'
+            "UserId": self.user_id,
+            "IncludeItemTypes": "MusicAlbum",
+            "Recursive": "true",
         }
 
-        url = self.api_url('/Items', url_params)
-        albums = self.http.get(url).get('Items')
+        url = self.api_url("/Items", url_params)
+        albums = self.http.get(url).get("Items")
 
         return albums
 
@@ -527,13 +488,13 @@ class JellyfinHandler(object):
         :returns Directory
         :rtype: dict
         """
-        url_params= {
-            'ParentId': id,
-            'SortOrder': 'Ascending',
-            'SortBy': 'SortName',
-            'fields': 'MediaSources'
+        url_params = {
+            "ParentId": id,
+            "SortOrder": "Ascending",
+            "SortBy": "SortName",
+            "fields": "MediaSources",
         }
-        url = self.api_url('/Users/{}/Items'.format(self.user_id), url_params)
+        url = self.api_url("/Users/{}/Items".format(self.user_id), url_params)
         return self.http.get(url)
 
     @cache()
@@ -546,12 +507,10 @@ class JellyfinHandler(object):
         :rtype: dict
         """
         data = self.http.get(
-            self.api_url(
-                '/Users/{}/Items/{}'.format(self.user_id, id)
-            )
+            self.api_url("/Users/{}/Items/{}".format(self.user_id, id))
         )
 
-        logger.debug('Jellyfin item: {}'.format(data))
+        logger.debug("Jellyfin item: {}".format(data))
 
         return data
 
@@ -564,32 +523,34 @@ class JellyfinHandler(object):
         :rtype: mopidy.models.Track
         """
         # TODO: add more metadata
-        name = track.get('Name')
+        name = track.get("Name")
         bitrate = 0
-        if self.watched_status and track.get('Type') == 'AudioBook':
-            if track['UserData'].get('PlayCount'):
-                name = f'[X] - {name}'
+        if self.watched_status and track.get("Type") == "AudioBook":
+            if track["UserData"].get("PlayCount"):
+                name = f"[X] - {name}"
             else:
-                name = f'[] - {name}'
+                name = f"[] - {name}"
 
-        for source in track.get('MediaSources', []):
-            for stream in source.get('MediaStreams', []):
-                if stream.get('Type') == 'Audio':
+        for source in track.get("MediaSources", []):
+            for stream in source.get("MediaStreams", []):
+                if stream.get("Type") == "Audio":
                     # Server returns bitrate in bits/sec, we need kbits
-                    bitrate = int(stream.get('BitRate', 0) / 1000)
+                    bitrate = int(stream.get("BitRate", 0) / 1000)
                     break
 
         return models.Track(
-            uri='jellyfin:track:{}'.format(track.get('Id')),
+            uri="jellyfin:track:{}".format(track.get("Id")),
             name=name,
             bitrate=bitrate,
-            track_no=track.get('IndexNumber', 0) if track.get('IndexNumber', 0) >= 0 else 0,
-            disc_no=track.get('ParentIndexNumber'),
-            genre=','.join(track.get('Genres', [])),
+            track_no=(
+                track.get("IndexNumber", 0) if track.get("IndexNumber", 0) >= 0 else 0
+            ),
+            disc_no=track.get("ParentIndexNumber"),
+            genre=",".join(track.get("Genres", [])),
             artists=self.create_artists(track),
             album=self.create_album(track),
-            length=self.ticks_to_milliseconds(track.get('RunTimeTicks', 0)),
-            date=self.parse_date(track)
+            length=self.ticks_to_milliseconds(track.get("RunTimeTicks", 0)),
+            date=self.parse_date(track),
         )
 
     def create_album(self, item):
@@ -600,20 +561,20 @@ class JellyfinHandler(object):
         :returns: Album
         :rtype: mopidy.models.Album
         """
-        item_type = item.get('Type')
-        if item_type == 'Audio':
+        item_type = item.get("Type")
+        if item_type == "Audio":
             return models.Album(
-                name=item.get('Album'),
+                name=item.get("Album"),
                 artists=self.create_artists(item),
                 uri=f'jellyfin:album:{item.get("AlbumId")}',
-                date=self.parse_date(item)
+                date=self.parse_date(item),
             )
-        elif item_type == 'MusicAlbum':
+        if item_type == "MusicAlbum":
             return models.Album(
-                name=item.get('Name'),
+                name=item.get("Name"),
                 artists=self.create_artists(item),
                 uri=f'jellyfin:album:{item.get("Id")}',
-                date=self.parse_date(item)
+                date=self.parse_date(item),
             )
 
     def create_artists(self, item={}, name=None):
@@ -626,22 +587,23 @@ class JellyfinHandler(object):
         :returns: List of artists
         :rtype: list of mopidy.models.Artist
         """
-        item_type = item.get('Type', '')
-        if item_type == 'MusicArtist':
+        item_type = item.get("Type", "")
+        if item_type == "MusicArtist":
             # Artists have a slightly different structure
             return [
-                models.Artist(name=item.get('Name'),
-                              uri=f'jellyfin:artist:{item.get("Id")}')
+                models.Artist(
+                    name=item.get("Name"), uri=f'jellyfin:artist:{item.get("Id")}'
+                )
             ]
         elif item_type:
             # For tracks and albums
             return [
                 models.Artist(name=artist, uri=f'jellyfin:artist:{item.get("Id")}')
-                for artist in item.get('Artists', [])
+                for artist in item.get("Artists", [])
             ]
         else:
             # In case we only get a name
-            return [ models.Artist(name=name) ]
+            return [models.Artist(name=name)]
 
     @cache()
     def get_track(self, track_id):
@@ -666,26 +628,23 @@ class JellyfinHandler(object):
         :returns: List of result dicts
         :rtype: list
         """
-        if itemtype == 'any':
-            search_query = 'Audio,MusicAlbum,MusicArtist'
-        elif itemtype == 'artist' or itemtype == 'albumartist':
-            search_query = 'MusicArtist'
-        elif itemtype == 'album':
-            search_query = 'MusicAlbum'
-        elif itemtype == 'track_name':
-            search_query = 'Audio'
+        if itemtype == "any":
+            search_query = "Audio,MusicAlbum,MusicArtist"
+        elif itemtype == "artist" or itemtype == "albumartist":
+            search_query = "MusicArtist"
+        elif itemtype == "album":
+            search_query = "MusicAlbum"
+        elif itemtype == "track_name":
+            search_query = "Audio"
         else:
-            raise Exception('Jellyfin search: no itemtype {}'.format(itemtype))
+            raise Exception("Jellyfin search: no itemtype {}".format(itemtype))
 
-        url_params = {
-            'SearchTerm': term,
-            'IncludeItemTypes': search_query
-        }
+        url_params = {"SearchTerm": term, "IncludeItemTypes": search_query}
 
-        url = self.api_url('/Search/Hints', url_params)
+        url = self.api_url("/Search/Hints", url_params)
         data = self.http.get(url)
 
-        return [i for i in data.get('SearchHints', [])]
+        return [i for i in data.get("SearchHints", [])]
 
     @cache()
     def search(self, query):
@@ -696,7 +655,7 @@ class JellyfinHandler(object):
         :returns: Search results
         :rtype: mopidy.models.SearchResult
         """
-        logger.debug('Searching in Jellyfin for {}'.format(query))
+        logger.debug("Searching in Jellyfin for {}".format(query))
 
         # something to store the results in
         data = []
@@ -708,133 +667,128 @@ class JellyfinHandler(object):
 
             for item in term:
 
-                data.extend(
-                    self._get_search(itemtype, item)
-                )
+                data.extend(self._get_search(itemtype, item))
 
         # walk through all items and create stuff
         for item in data:
 
-            if item.get('Type') == 'Audio':
+            if item.get("Type") == "Audio":
                 tracks.append(self.create_track(item))
 
-            elif item.get('Type') == 'MusicAlbum':
+            elif item.get("Type") == "MusicAlbum":
                 albums.append(self.create_album(item))
 
-            elif item.get('Type') == 'MusicArtist':
+            elif item.get("Type") == "MusicArtist":
                 artists.extend(self.create_artists(item))
 
         return models.SearchResult(
-            uri='jellyfin:search',
-            tracks=tracks,
-            artists=artists,
-            albums=albums
+            uri="jellyfin:search", tracks=tracks, artists=artists, albums=albums
         )
-
 
     @cache()
     def exact_search(self, query):
         # Variable prep
         tracks = []
-        raw_artist = ''
+        raw_artist = ""
         artist_ref = []
         albums = []
 
         # Check query for artist name
-        if 'artist' in query:
-            raw_artist = query.get('artist')
-        elif 'albumartist' in query:
-            raw_artist = query.get('albumartist')
+        if "artist" in query:
+            raw_artist = query.get("artist")
+        elif "albumartist" in query:
+            raw_artist = query.get("albumartist")
 
         # Use if query has artist name
         if raw_artist:
             # URL encode artist string
-            artist = quote(raw_artist[0].encode('utf8')).replace('/', '-')
+            artist = quote(raw_artist[0].encode("utf8")).replace("/", "-")
             artist_ref = self.create_artists(name=raw_artist[0])
-            url_params = { 'UserId': self.user_id }
-            url = self.api_url('/Artists/{}'.format(artist), url_params)
+            url_params = {"UserId": self.user_id}
+            url = self.api_url("/Artists/{}".format(artist), url_params)
 
             artist_data = self.http.get(url)
-            artist_id = artist_data.get('Id')
+            artist_id = artist_data.get("Id")
 
             url_params = {
-                'IncludeItemTypes': 'MusicAlbum',
-                'Recursive': 'true',
-                'UserId': self.user_id,
-                'fields': 'MediaSources'
+                "IncludeItemTypes": "MusicAlbum",
+                "Recursive": "true",
+                "UserId": self.user_id,
+                "fields": "MediaSources",
             }
 
             # Get album list
             if self.albumartistsort:
-                url_params['AlbumArtistIds'] = artist_id
+                url_params["AlbumArtistIds"] = artist_id
             else:
-                url_params['ArtistIds'] = artist_id
+                url_params["ArtistIds"] = artist_id
 
-            album_url = self.api_url('/Items', url_params)
+            album_url = self.api_url("/Items", url_params)
             album_data = self.http.get(album_url)
             if album_data:
-                contents = album_data.get('Items')
+                contents = album_data.get("Items")
                 for item in contents:
-                    if item.get('Type') == 'MusicAlbum':
+                    if item.get("Type") == "MusicAlbum":
                         album_obj = models.Album(
-                            name=item.get('Name'),
+                            name=item.get("Name"),
                             artists=self.create_artists(item),
-                            uri='jellyfin:album:{}'.format(item.get('Id')),
-                            date=self.parse_date(item)
+                            uri="jellyfin:album:{}".format(item.get("Id")),
+                            date=self.parse_date(item),
                         )
                         if album_obj not in albums:
                             albums.append(album_obj)
 
             # Get artist tracks
-            url_params['IncludeItemTypes'] = 'Audio'
-            track_url = self.api_url('/Items', url_params)
+            url_params["IncludeItemTypes"] = "Audio"
+            track_url = self.api_url("/Items", url_params)
             track_data = self.http.get(track_url)
             if track_data:
                 # If the query has an album, only match those tracks
-                if query.get('album'):
+                if query.get("album"):
                     tracks = [
                         self.create_track(track)
-                        for track in track_data.get('Items')
-                        if track.get('Album') == query.get('album')[0]
+                        for track in track_data.get("Items")
+                        if track.get("Album") == query.get("album")[0]
                     ]
                 # Otherwise return all tracks
                 else:
                     tracks = [
-                        self.create_track(track)
-                        for track in track_data.get('Items')
+                        self.create_track(track) for track in track_data.get("Items")
                     ]
 
         # Use if query only has an album name
-        elif 'album' in query:
-            album_name = query.get('album')[0]
+        elif "album" in query:
+            album_name = query.get("album")[0]
             url_params = {
-                'IncludeItemTypes': 'MusicAlbum',
-                'IncludeMedia': 'true',
-                'Recursive': 'true',
-                'searchTerm': album_name,
-                'fields': 'MediaSources'
+                "IncludeItemTypes": "MusicAlbum",
+                "IncludeMedia": "true",
+                "Recursive": "true",
+                "searchTerm": album_name,
+                "fields": "MediaSources",
             }
-            url = self.api_url('/Users/{}/Items'.format(self.user_id), url_params)
-            album_data = self.http.get(url).get('Items')
+            url = self.api_url("/Users/{}/Items".format(self.user_id), url_params)
+            album_data = self.http.get(url).get("Items")
             tracks = []
             # This can lead to false matches, but all we have at this point
             # is an album name to match against.  Options are limited
             for album in album_data:
-                if album.get('Name') == album_name:
+                if album.get("Name") == album_name:
                     album_obj = models.Album(
-                        name=album.get('Name'),
+                        name=album.get("Name"),
                         artists=self.create_artists(album),
-                        uri='jellyfin:album:{}'.format(album.get('Id')),
-                        date=self.parse_date(album)
+                        uri="jellyfin:album:{}".format(album.get("Id")),
+                        date=self.parse_date(album),
                     )
                     if album_obj not in albums:
                         albums.append(album_obj)
-                    raw_tracks = self.get_directory(album.get('Id'))
-                    tracks += [self.create_track(track)
-                               for track in raw_tracks.get('Items', [])]
+                    raw_tracks = self.get_directory(album.get("Id"))
+                    tracks += [
+                        self.create_track(track)
+                        for track in raw_tracks.get("Items", [])
+                    ]
 
         return models.SearchResult(
-            uri='jellyfin:search',
+            uri="jellyfin:search",
             tracks=tracks,
             albums=albums,
             artists=artist_ref,
@@ -845,17 +799,17 @@ class JellyfinHandler(object):
         tracks = []
 
         url_params = {
-            'IncludeItemTypes': 'Audio',
-            'Recursive': 'true',
-            'AlbumIds': album_id,
-            'UserId': self.user_id,
-            'fields': 'MediaSources'
+            "IncludeItemTypes": "Audio",
+            "Recursive": "true",
+            "AlbumIds": album_id,
+            "UserId": self.user_id,
+            "fields": "MediaSources",
         }
-        url = self.api_url('/Items', url_params)
+        url = self.api_url("/Items", url_params)
 
         result = self.http.get(url)
         if result:
-            raw_tracks = result.get('Items')
+            raw_tracks = result.get("Items")
 
         if artist_ref:
             # If the artist was in the query,
@@ -863,15 +817,12 @@ class JellyfinHandler(object):
             tracks = [
                 self.create_track(track)
                 for track in raw_tracks
-                if unidecode(artist_ref[0].name.lower()) in (
-                    artist.lower() for artist in track.get('Artists'))
+                if unidecode(artist_ref[0].name.lower())
+                in (artist.lower() for artist in track.get("Artists"))
             ]
         else:
             # If the query doesn't contain an artist, return all tracks
-            tracks = [
-                self.create_track(track)
-                for track in raw_tracks
-            ]
+            tracks = [self.create_track(track) for track in raw_tracks]
 
         return tracks
 
@@ -881,8 +832,7 @@ class JellyfinHandler(object):
         try:
             return self.album_format.format(**item)
         except:
-            return item.get('Name')
-
+            return item.get("Name")
 
     def lookup_artist(self, artist_id):
         """Lookup all artist tracks and sort them.
@@ -893,34 +843,32 @@ class JellyfinHandler(object):
         :rtype: list
         """
         url_params = {
-            'SortOrder': 'Ascending',
-            'SortBy': 'SortName',
-            'Recursive': 'true',
-            'IncludeItemTypes': 'Audio',
-            'fields': 'MediaSources'
+            "SortOrder": "Ascending",
+            "SortBy": "SortName",
+            "Recursive": "true",
+            "IncludeItemTypes": "Audio",
+            "fields": "MediaSources",
         }
         if self.albumartistsort:
-            url_params['AlbumArtistIds'] = artist_id
+            url_params["AlbumArtistIds"] = artist_id
         else:
-            url_params['ArtistIds'] = artist_id
+            url_params["ArtistIds"] = artist_id
 
-        url = self.api_url('/Users/{}/Items'.format(self.user_id), url_params)
+        url = self.api_url("/Users/{}/Items".format(self.user_id), url_params)
         items = self.http.get(url)
 
         # sort tracks into album keys
         album_dict = defaultdict(list)
-        for track in items.get('Items'):
-            album_dict[track.get('Album')].append(track)
+        for track in items.get("Items"):
+            album_dict[track.get("Album")].append(track)
 
         # order albums in alphabet
         album_dict = OrderedDict(sorted(album_dict.items()))
 
         # sort tracks in album dict
         tracks = []
-        for album, track_list in album_dict.items():
-            track_list.sort(
-                key=lambda k: (k.get('IndexNumber', 0), k.get('Name'))
-            )
+        for _, track_list in album_dict.items():
+            track_list.sort(key=lambda k: (k.get("IndexNumber", 0), k.get("Name")))
 
             # add tracks to list
             tracks.extend(track_list)
@@ -950,7 +898,7 @@ class JellyfinHandler(object):
         return milliseconds * 10000
 
     def get_image(self, item_id):
-        url = f'{self.hostname}/Items/{item_id}/Images/Primary'
+        url = f"{self.hostname}/Items/{item_id}/Images/Primary"
         # Verify if image exists instead of returning bad URLs
         image = self.http.head(item_id, url)
         if image:
@@ -961,17 +909,22 @@ class JellyfinHandler(object):
             return []
 
     def parse_date(self, item):
-        '''
+        """
         Build the date format required for mopidy models
-        '''
-        datestring = item.get('PremiereDate')
+        """
+        datestring = item.get("PremiereDate")
+        date = "1970-01-01"  # Fallback date if nothing else is available
 
         if datestring:
             # Premiere dates from JF are in format '2019-12-13T00:00:00.0000000Z'
             # We only need the first part
-            date = datestring.split('T')[0]
-        else:
-           # Take the production year if PremiereDate isn't available
-           # Fall back to an empty string for no data
-           date = str(item.get('ProductionYear', ''))
+            date = datestring.split("T")[0]
+        elif item.get("ProductionYear"):
+            # Take the production year if PremiereDate isn't available
+            # Fall back to an empty string for no data
+            date = str(item["ProductionYear"])
+        elif item.get("DateCreated"):
+            # Use DateCreated if no PremiereDate or ProductionYear
+            date = item["DateCreated"].split("T")[0]
+
         return date


### PR DESCRIPTION
Mopidy v4.0 has migrated to Pydantic instead of the previous self-made (and more tolerant) schemas, and a track or album can't have an empty string as a date.

Pydantic will fail with:

```
  File "/home/blacklight/git_tree/mopidy/venv/lib/python3.13/site-packages/pydantic/main.py", line 253, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for Album
date
  String should match pattern '^\d{4}(-\d{2}-\d{2})?$' [type=string_pattern_mismatch, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/string_pattern_mismatch
```

This fixes the issue by falling back to `DateCreated` (which should always be provided by the server), and just in case it falls back to 1970-01-01 if that isn't available either.

Closes: #154 